### PR TITLE
correção do pacote psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 flask
 flask_sqlalchemy
-psycopg2
+psycopg2-binary


### PR DESCRIPTION
correção de acordo com o erro relatado no Vercel, importando uma versão alternativa do pacote