### PR TITLE
lida de forma simplificada com erro de cors

### DIFF
--- a/main/__init__.py
+++ b/main/__init__.py
@@ -1,5 +1,6 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flask_cors import CORS
 import os
 
 PASSWORD = os.environ.get('POSTGRES_PASSWORD')
@@ -7,6 +8,7 @@ PASSWORD = os.environ.get('POSTGRES_PASSWORD')
 app = Flask(__name__)
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://default:{}@ep-autumn-dream-20888543.us-east-1.postgres.vercel-storage.com:5432/verceldb'.format(PASSWORD)
+CORS(app)
 db = SQLAlchemy(app)
 
 @app.route("/")


### PR DESCRIPTION
a biblioteca instalada permite a comunicação com outra aplicação web sem gerar o erro de cross origin resource sharing. Ele lida de forma simplificada, pois dá a permissão para qualquer rota, quando, idealmente, não é a forma mais segura. Acredito que, por agilidade, possa ser feito assim.